### PR TITLE
Add indent-blankline-nvim

### DIFF
--- a/home/neovim/default.nix
+++ b/home/neovim/default.nix
@@ -50,6 +50,7 @@
       symbols-outline-nvim
       nvim-lspconfig
       rust-tools-nvim
+      indent-blankline-nvim
 
       neo-tree-nvim
       nui-nvim

--- a/home/neovim/init.lua
+++ b/home/neovim/init.lua
@@ -727,3 +727,7 @@ rt.setup({
   },
 })
 -- }}}
+-- {{{
+vim.cmd([[ hi IndentBlanklineChar guifg=#330000 ]])
+require("ibl").setup({})
+-- }}}


### PR DESCRIPTION
Merge when fixed:

```
Error detected while processing /Users/ivan/.config/nvim/init.lua:
E5113: Error while calling lua chunk: /Users/ivan/.config/nvim/init.lua:732: module 'ibl' not found:
        no field package.preload['ibl']
        no file '/nix/store/akxl2mc917zck5xjma565cfsb7vp0xqa-luajit-2.1.0-2022-10-04-env/share/lua/5.1/ibl.lua'
        no file '/nix/store/akxl2mc917zck5xjma565cfsb7vp0xqa-luajit-2.1.0-2022-10-04-env/share/lua/5.1/ibl/init.lua'
        no file '/nix/store/akxl2mc917zck5xjma565cfsb7vp0xqa-luajit-2.1.0-2022-10-04-env/lib/lua/5.1/ibl.so'
stack traceback:
        [C]: in function 'require'
        /Users/ivan/.config/nvim/init.lua:732: in main chunk
```